### PR TITLE
feat: default deny auth guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ redigera `.env.development.local` för behov. URLer, nycklar och cert behöver f
    - För frontend, se till att backend är igång (`yarn dev`), i /frontend kör `yarn generate:contracts` för att synca backend med frontend
      -- Justera om så behövs utifrån de uppdaterade modellerna
 
+### Backend-routes och autentisering
+
+Alla routes i backenden kräver autentisering som standard — en inloggad session måste finnas, annars svarar servern 401. Det är inte möjligt att råka glömma bort skyddet på en ny endpoint.
+
+**Lägga till en ny skyddad route** — gör ingenting extra. Lägg till controller och handler som vanligt; skyddet är automatiskt.
+
+**Lägga till en publik route** — dekorera handler med `@Public('motivering')`:
+
+```ts
+import { Public } from '@/middlewares/public.decorator';
+
+@Get('/health/up')
+@Public('Liveness probe - pollas av infrastrukturen utan session')
+async up() { ... }
+```
+
+Motiveringstexten loggas vid uppstart och fångas i ett snapshot-test, så varje förändring framgår i kodgranskning.
+
+**Lägga till en ny controller** — lägg till klassen i `src/controllers.ts`. Controllern täcks då automatiskt av autentiseringsskyddet och av auth-testerna.
+
+**Tester** — tre testsviter bevakar skyddet:
+
+| Fil | Vad den testar |
+| --- | --- |
+| `src/tests/default-auth.metadata.test.ts` | Källkodsnivå: varje route har antingen `@UseBefore(authMiddleware)` eller `@Public()` |
+| `src/tests/default-auth.runtime.test.ts` | Runtime: varje oskyddad route svarar 401 utan session |
+| `src/tests/default-auth.swagger.test.ts` | Swagger UI är nåbar utan session |
+
 ### Kvalitetsgrindar & test
 
 Repot har strikta, type-aware kvalitetsgrindar. Kör hela sviten från roten med `yarn verify`

--- a/README.md
+++ b/README.md
@@ -70,7 +70,18 @@ redigera `.env.development.local` för behov. URLer, nycklar och cert behöver f
 
 Alla routes i backenden kräver autentisering som standard — en inloggad session måste finnas, annars svarar servern 401. Det är inte möjligt att råka glömma bort skyddet på en ny endpoint.
 
-**Lägga till en ny skyddad route** — gör ingenting extra. Lägg till controller och handler som vanligt; skyddet är automatiskt.
+**Lägga till en ny skyddad route** — dekorera handler med `@UseBefore(authMiddleware)`:
+
+```ts
+import authMiddleware from '@middlewares/auth.middleware';
+import { UseBefore } from 'routing-controllers';
+
+@Get('/me')
+@UseBefore(authMiddleware)
+getUser() { ... }
+```
+
+Själva 401-svaret kommer inte från dekoratorn. Det kommer från en middleware som mountas framför hela `BASE_URL_PREFIX` innan controllers registreras (`createDefaultAuthGuard` i `backend/src/middlewares/default-auth.middleware.ts`) — den nekar allt som inte är märkt `@Public()`, så en ny route är skyddad så fort den finns. Dekoratorn behövs ändå: den deklarerar avsikten i koden. En route utan vare sig `@UseBefore(authMiddleware)` eller `@Public()` failar `default-auth.metadata.test.ts`, så skyddet kan varken glömmas bort eller tas bort tyst.
 
 **Lägga till en publik route** — dekorera handler med `@Public('motivering')`:
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -20,7 +20,9 @@ import {
   SECRET_KEY,
   SWAGGER_ENABLED,
 } from '@config';
+import { createDefaultAuthGuard } from '@middlewares/default-auth.middleware';
 import errorMiddleware from '@middlewares/error.middleware';
+import { buildPublicPathSet, PublicRouteInfo } from '@middlewares/public.decorator';
 import { Profile as SamlProfile, Strategy, VerifiedCallback } from '@node-saml/passport-saml';
 import { logger, stream } from '@utils/logger';
 import bodyParser from 'body-parser';
@@ -158,7 +160,8 @@ class App {
     this.initializeDataFolders();
 
     this.initializeLivenessRoute();
-    this.initializeMiddlewares();
+    const { paths: publicPaths, routes: publicRoutes } = buildPublicPathSet(Controllers);
+    this.initializeMiddlewares(publicPaths, publicRoutes);
     this.initializeRoutes(Controllers);
     if (this.swaggerEnabled) {
       this.initializeSwagger(Controllers);
@@ -188,7 +191,7 @@ class App {
     this.app.get('/health', livenessHandler);
   }
 
-  private initializeMiddlewares() {
+  private initializeMiddlewares(publicPaths: Set<string>, publicRoutes: PublicRouteInfo[]) {
     // Trust the nearest reverse proxy so req.ip and rate limiting use the client address.
     this.app.set('trust proxy', 1);
     this.app.use(morgan(LOG_FORMAT, { stream }));
@@ -389,6 +392,17 @@ class App {
       }) as RequestHandler;
       authenticate(req, res, next);
     });
+
+    // Default-deny authentication. Mounted last so the SAML endpoints above it stay
+    // reachable, and before initializeRoutes() so every routing-controllers route sits
+    // behind it unless its handler carries @Public().
+    for (const route of publicRoutes) {
+      logger.warn(
+        `Auth guard: PUBLIC ${route.httpMethod} ${route.path} (${route.controller}.${route.action})` +
+          (route.reason ? ` - ${route.reason}` : ' - no reason given'),
+      );
+    }
+    this.app.use(BASE_URL_PREFIX, createDefaultAuthGuard(publicPaths));
   }
 
   private initializeRoutes(controllers: ControllerClass[]) {

--- a/backend/src/config/public-paths.ts
+++ b/backend/src/config/public-paths.ts
@@ -1,26 +1,39 @@
 /**
  * Non-controller Express mounts reachable without authentication.
  *
- * Keep this list minimal - prefix matching grants a whole subtree.
+ * Keep this list minimal - prefix matching grants a whole subtree, for every method.
  */
 const PUBLIC_PATH_PREFIXES: readonly string[] = ['/api-docs', '/swagger.json'];
 
 /** Strips a single trailing slash so '/health/up/' matches '/health/up'. Keeps a bare '/'. */
 const normalizePath = (path: string): string => (path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path);
 
-/**
- * True when the path may be served without an authenticated session.
- *
- * `publicPaths` is an exact-match set built from @Public() decorators at startup.
- * PUBLIC_PATH_PREFIXES opts in to subtree matching, only on a segment boundary -
- * '/api-docs' must not match '/api-docsomething'.
- */
-export const isPublicPath = (path: string, publicPaths: Set<string>): boolean => {
-  const normalized = normalizePath(path);
+/** Express answers HEAD from the matching GET handler, so a public GET has to accept HEAD too. */
+const normalizeMethod = (httpMethod: string): string => {
+  const upper = httpMethod.toUpperCase();
+  return upper === 'HEAD' ? 'GET' : upper;
+};
 
-  if (publicPaths.has(normalized)) {
+/**
+ * Key format for the allow-list built by buildPublicPathSet(). Method-scoped on purpose:
+ * @Public() sits on a single handler, so marking GET public must not open POST on the
+ * same path.
+ */
+export const publicRouteKey = (httpMethod: string, path: string): string => `${normalizeMethod(httpMethod)} ${normalizePath(path)}`;
+
+/**
+ * True when this method/path pair may be served without an authenticated session.
+ *
+ * `publicPaths` is an exact-match set of 'METHOD /path' keys built from @Public()
+ * decorators at startup. PUBLIC_PATH_PREFIXES opts in to subtree matching for every
+ * method, only on a segment boundary - '/api-docs' must not match '/api-docsomething'.
+ */
+export const isPublicPath = (httpMethod: string, path: string, publicPaths: Set<string>): boolean => {
+  if (publicPaths.has(publicRouteKey(httpMethod, path))) {
     return true;
   }
+
+  const normalized = normalizePath(path);
 
   return PUBLIC_PATH_PREFIXES.some(prefix => normalized === prefix || normalized.startsWith(`${prefix}/`));
 };

--- a/backend/src/config/public-paths.ts
+++ b/backend/src/config/public-paths.ts
@@ -1,0 +1,26 @@
+/**
+ * Non-controller Express mounts reachable without authentication.
+ *
+ * Keep this list minimal - prefix matching grants a whole subtree.
+ */
+const PUBLIC_PATH_PREFIXES: readonly string[] = ['/api-docs', '/swagger.json'];
+
+/** Strips a single trailing slash so '/health/up/' matches '/health/up'. Keeps a bare '/'. */
+const normalizePath = (path: string): string => (path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path);
+
+/**
+ * True when the path may be served without an authenticated session.
+ *
+ * `publicPaths` is an exact-match set built from @Public() decorators at startup.
+ * PUBLIC_PATH_PREFIXES opts in to subtree matching, only on a segment boundary -
+ * '/api-docs' must not match '/api-docsomething'.
+ */
+export const isPublicPath = (path: string, publicPaths: Set<string>): boolean => {
+  const normalized = normalizePath(path);
+
+  if (publicPaths.has(normalized)) {
+    return true;
+  }
+
+  return PUBLIC_PATH_PREFIXES.some(prefix => normalized === prefix || normalized.startsWith(`${prefix}/`));
+};

--- a/backend/src/controllers.ts
+++ b/backend/src/controllers.ts
@@ -1,0 +1,5 @@
+import { HealthController } from './controllers/health.controller';
+import { IndexController } from './controllers/index.controller';
+import { UserController } from './controllers/user.controller';
+
+export const CONTROLLERS = [IndexController, UserController, HealthController];

--- a/backend/src/controllers/health.controller.ts
+++ b/backend/src/controllers/health.controller.ts
@@ -3,6 +3,7 @@ import { OpenAPI } from 'routing-controllers-openapi';
 
 import { getApiBase } from '@/config/api-config';
 import { HttpException } from '@/exceptions/HttpException';
+import { Public } from '@/middlewares/public.decorator';
 import ApiService from '@/services/api.service';
 import { logger } from '@/utils/logger';
 import { isRedisReady } from '@/utils/redis';
@@ -14,6 +15,7 @@ export class HealthController {
 
   @Get('/health/up')
   @OpenAPI({ summary: 'Return health check' })
+  @Public('Liveness probe - polled by infrastructure without a session')
   async up(): Promise<{ status: string }> {
     if (!isRedisReady()) {
       logger.error('Health check failed: Redis is not ready');

--- a/backend/src/controllers/index.controller.ts
+++ b/backend/src/controllers/index.controller.ts
@@ -1,8 +1,11 @@
 import { Controller, Get } from 'routing-controllers';
 
+import { Public } from '@/middlewares/public.decorator';
+
 @Controller()
 export class IndexController {
   @Get('/')
+  @Public('Service root - returns a constant, no user context')
   index() {
     return 'OK';
   }

--- a/backend/src/middlewares/default-auth.middleware.ts
+++ b/backend/src/middlewares/default-auth.middleware.ts
@@ -18,7 +18,7 @@ export const createDefaultAuthGuard =
       return;
     }
 
-    if (isPublicPath(req.path, publicPaths)) {
+    if (isPublicPath(req.method, req.path, publicPaths)) {
       next();
       return;
     }

--- a/backend/src/middlewares/default-auth.middleware.ts
+++ b/backend/src/middlewares/default-auth.middleware.ts
@@ -1,0 +1,27 @@
+import authMiddleware from '@middlewares/auth.middleware';
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { isPublicPath } from '@/config/public-paths';
+
+/**
+ * App-level default-deny authentication.
+ *
+ * Returns a middleware closed over the set of public paths built at startup from
+ * @Public() decorators. Mounted once in app.ts before the routing-controllers routes
+ * are registered, so every route is authenticated unless its handler carries @Public().
+ */
+export const createDefaultAuthGuard =
+  (publicPaths: Set<string>): RequestHandler =>
+  (req: Request, res: Response, next: NextFunction) => {
+    if (req.method === 'OPTIONS') {
+      next();
+      return;
+    }
+
+    if (isPublicPath(req.path, publicPaths)) {
+      next();
+      return;
+    }
+
+    authMiddleware(req, res, next);
+  };

--- a/backend/src/middlewares/public.decorator.ts
+++ b/backend/src/middlewares/public.decorator.ts
@@ -1,0 +1,69 @@
+import { getMetadataArgsStorage } from 'routing-controllers';
+
+export interface PublicRouteInfo {
+  path: string;
+  httpMethod: string;
+  controller: string;
+  action: string;
+  reason?: string;
+}
+
+const publicClasses = new Map<unknown, string | undefined>();
+const publicMethods = new Map<unknown, Map<string, string | undefined>>();
+
+/**
+ * Marks a controller action (or every action on a controller) as reachable without
+ * an authenticated session. The guard will let these paths through; everything else
+ * requires auth by default.
+ */
+export function Public(reason?: string): MethodDecorator & ClassDecorator {
+  return (target: object, propertyKey?: string | symbol): void => {
+    if (propertyKey === undefined) {
+      publicClasses.set(target, reason);
+      return;
+    }
+    const ctor: unknown = typeof target === 'function' ? target : (target as { constructor: unknown }).constructor;
+    let methods = publicMethods.get(ctor);
+    if (!methods) {
+      methods = new Map();
+      publicMethods.set(ctor, methods);
+    }
+    methods.set(String(propertyKey), reason);
+  };
+}
+
+export function resolvePublic(target: unknown, method: string): { isPublic: boolean; reason?: string } {
+  if (publicClasses.has(target)) return { isPublic: true, reason: publicClasses.get(target) };
+  const methods = publicMethods.get(target);
+  if (methods?.has(method)) return { isPublic: true, reason: methods.get(method) };
+  return { isPublic: false };
+}
+
+/**
+ * Call this after controllers have been imported (their decorators must have run)
+ * and before the Express server starts accepting requests.
+ */
+export function buildPublicPathSet(controllers: (new (...args: never[]) => object)[]): { paths: Set<string>; routes: PublicRouteInfo[] } {
+  const storage = getMetadataArgsStorage();
+  const mounted = new Set<unknown>(controllers);
+  const controllerRouteByTarget = new Map<unknown, unknown>(storage.controllers.map(c => [c.target, c.route]));
+  const routes: PublicRouteInfo[] = [];
+
+  for (const action of storage.actions) {
+    if (!mounted.has(action.target)) continue;
+    const { isPublic, reason } = resolvePublic(action.target, action.method ?? '');
+    if (!isPublic) continue;
+
+    const prefix = typeof controllerRouteByTarget.get(action.target) === 'string' ? String(controllerRouteByTarget.get(action.target)) : '';
+    const route = typeof action.route === 'string' ? action.route : String(action.route ?? '');
+    routes.push({
+      path: `${prefix}${route}` || '/',
+      httpMethod: (action.type ?? '').toUpperCase(),
+      controller: (action.target as { name?: string }).name ?? 'unknown',
+      action: action.method ?? '',
+      reason,
+    });
+  }
+
+  return { paths: new Set(routes.map(r => r.path)), routes };
+}

--- a/backend/src/middlewares/public.decorator.ts
+++ b/backend/src/middlewares/public.decorator.ts
@@ -1,5 +1,7 @@
 import { getMetadataArgsStorage } from 'routing-controllers';
 
+import { publicRouteKey } from '@/config/public-paths';
+
 export interface PublicRouteInfo {
   path: string;
   httpMethod: string;
@@ -65,5 +67,5 @@ export function buildPublicPathSet(controllers: (new (...args: never[]) => objec
     });
   }
 
-  return { paths: new Set(routes.map(r => r.path)), routes };
+  return { paths: new Set(routes.map(r => publicRouteKey(r.httpMethod, r.path))), routes };
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,15 +1,12 @@
 import type { Server } from 'node:http';
 
-import { IndexController } from '@controllers/index.controller';
 import { logger } from '@utils/logger';
 import { closeRedisClient, destroyRedisClient } from '@utils/redis';
 import { createSessionStore } from '@utils/session-store';
 import validateEnv from '@utils/validateEnv';
 
 import App from '@/app';
-
-import { HealthController } from './controllers/health.controller';
-import { UserController } from './controllers/user.controller';
+import { CONTROLLERS } from '@/controllers';
 
 const SHUTDOWN_GRACE_PERIOD_MS = 10_000;
 
@@ -92,7 +89,7 @@ export async function startServer(): Promise<void> {
 
   try {
     const sessionStore = await createSessionStore();
-    const app = new App([IndexController, UserController, HealthController], sessionStore);
+    const app = new App(CONTROLLERS, sessionStore);
     server = app.listen();
   } catch (error: unknown) {
     try {

--- a/backend/src/tests/default-auth.metadata.test.ts
+++ b/backend/src/tests/default-auth.metadata.test.ts
@@ -1,0 +1,53 @@
+// Source-level guard for the default-deny auth model.
+//
+// Walks every route routing-controllers has registered and asserts that every route
+// without authMiddleware carries @Public(). This catches a new unauthenticated route
+// at the point it is added, without booting the app.
+//
+// This test is about declared intent. The runtime counterpart
+// (default-auth.runtime.test.ts) proves the app-level guard actually denies these requests.
+
+import { describe, expect, it } from 'vitest';
+
+import { CONTROLLERS } from '@/controllers';
+
+import { collectRegisteredRoutes } from './helpers/routes';
+
+describe('default-deny auth (metadata)', () => {
+  const routes = collectRegisteredRoutes();
+
+  it('registers routes for every mounted controller', () => {
+    expect(routes.length).toBeGreaterThan(0);
+
+    const controllersWithRoutes = new Set(routes.map(route => route.controllerName));
+    expect(controllersWithRoutes.size).toBe(CONTROLLERS.length);
+  });
+
+  it('has no route that is both unauthenticated and not marked @Public()', () => {
+    const unguarded = routes
+      .filter(route => !route.hasAuthMiddleware && !route.isPublic)
+      .map(route => `${route.httpMethod.toUpperCase()} ${route.path} (${route.controllerName}.${route.handlerName})`);
+
+    expect(unguarded).toEqual([]);
+  });
+
+  it('has no route marked both @Public() and @UseBefore(authMiddleware)', () => {
+    const contradictory = routes
+      .filter(route => route.isPublic && route.hasAuthMiddleware)
+      .map(route => `${route.httpMethod.toUpperCase()} ${route.path}`);
+
+    expect(contradictory).toEqual([]);
+  });
+
+  it('pins the set of public routes with their stated reasons', () => {
+    const publicSurface = routes
+      .filter(route => route.isPublic)
+      .map(route => `${route.httpMethod.toUpperCase()} ${route.path} // ${route.publicReason ?? 'no reason given'}`)
+      .sort();
+
+    expect(publicSurface).toEqual([
+      'GET / // Service root - returns a constant, no user context',
+      'GET /health/up // Liveness probe - polled by infrastructure without a session',
+    ]);
+  });
+});

--- a/backend/src/tests/default-auth.runtime.test.ts
+++ b/backend/src/tests/default-auth.runtime.test.ts
@@ -4,9 +4,10 @@
 // sends an unauthenticated request to every registered route. Everything must answer 401
 // except routes marked @Public().
 //
-// This is the assertion that actually matters: it proves the app-level guard denies by
-// default, independently of what any decorator claims. The metadata test covers declared
-// intent; this one covers behaviour.
+// The metadata test covers declared intent; this one covers behaviour. Note that a 401 on
+// a real route proves only that *something* denied it - every protected route also carries
+// its own @UseBefore(authMiddleware). GuardFixtureController is what isolates the guard:
+// it mounts a route with no auth decorator at all, so only the guard can deny it.
 
 import session from 'express-session';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -15,6 +16,7 @@ import App from '@/app';
 import { BASE_URL_PREFIX } from '@/config';
 import { CONTROLLERS } from '@/controllers';
 
+import { GuardFixtureController, PublicControllerFixture } from './fixtures/guard.fixture.controller';
 import { collectRegisteredRoutes, toConcretePath } from './helpers/routes';
 import { startServer, TestServer } from './helpers/server';
 
@@ -41,7 +43,7 @@ describe('default-deny auth (runtime)', () => {
   let server: TestServer;
 
   beforeAll(async () => {
-    server = await startServer(new App(CONTROLLERS, new session.MemoryStore()).getServer());
+    server = await startServer(new App([...CONTROLLERS, GuardFixtureController, PublicControllerFixture], new session.MemoryStore()).getServer());
   });
 
   afterAll(() => server.close());
@@ -85,6 +87,22 @@ describe('default-deny auth (runtime)', () => {
     const response = await send('options', target.path);
 
     expect(response.status).not.toBe(401);
+  });
+
+  it('denies a route carrying no auth decorator, proving the guard denies on its own', async () => {
+    const mounted = await server.request('get', `${BASE_URL_PREFIX}/__guard-fixture__/reachable`);
+    expect(mounted.status).toBe(200);
+
+    const response = await server.request('get', `${BASE_URL_PREFIX}/__guard-fixture__/unguarded`);
+    expect(response.status).toBe(401);
+  });
+
+  it('keeps a @UseBefore(authMiddleware) route protected inside a @Public() controller', async () => {
+    const sibling = await server.request('get', `${BASE_URL_PREFIX}/__public-class-fixture__/inherited`);
+    expect(sibling.status).toBe(200);
+
+    const response = await server.request('get', `${BASE_URL_PREFIX}/__public-class-fixture__/protected`);
+    expect(response.status).toBe(401);
   });
 
   it('denies an unknown path under the prefix rather than falling through', async () => {

--- a/backend/src/tests/default-auth.runtime.test.ts
+++ b/backend/src/tests/default-auth.runtime.test.ts
@@ -1,0 +1,88 @@
+// Runtime guard for the default-deny auth model.
+//
+// Boots the real App (same middleware order as production, in-memory session store) and
+// sends an unauthenticated request to every registered route. Everything must answer 401
+// except routes marked @Public().
+//
+// This is the assertion that actually matters: it proves the app-level guard denies by
+// default, independently of what any decorator claims. The metadata test covers declared
+// intent; this one covers behaviour.
+
+import session from 'express-session';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import App from '@/app';
+import { BASE_URL_PREFIX } from '@/config';
+import { CONTROLLERS } from '@/controllers';
+
+import { collectRegisteredRoutes, toConcretePath } from './helpers/routes';
+import { startServer, TestServer } from './helpers/server';
+
+vi.mock('@/services/api.service', () => {
+  const stub = vi.fn(() => Promise.resolve({ data: {} }));
+  return {
+    default: class {
+      get = stub;
+      post = stub;
+      patch = stub;
+      put = stub;
+      delete = stub;
+    },
+  };
+});
+
+vi.mock('@/utils/redis', () => ({
+  isRedisReady: () => true,
+  closeRedisClient: () => Promise.resolve(),
+  destroyRedisClient: () => undefined,
+}));
+
+describe('default-deny auth (runtime)', () => {
+  let server: TestServer;
+
+  beforeAll(async () => {
+    server = await startServer(new App(CONTROLLERS, new session.MemoryStore()).getServer());
+  });
+
+  afterAll(() => server.close());
+
+  const routes = collectRegisteredRoutes();
+  const protectedRoutes = routes.filter(route => !route.isPublic);
+  const publicRoutes = routes.filter(route => route.isPublic);
+
+  const send = (httpMethod: string, path: string) => server.request(httpMethod, `${BASE_URL_PREFIX}${toConcretePath(path)}`);
+
+  it('enumerates the routes it is about to probe', () => {
+    expect(protectedRoutes.length).toBeGreaterThan(0);
+    expect(publicRoutes.length).toBeGreaterThan(0);
+  });
+
+  it.each(protectedRoutes.map(route => [`${route.httpMethod.toUpperCase()} ${route.path}`, route]))(
+    'denies %s without a session',
+    async (_label, route) => {
+      const response = await send(route.httpMethod, route.path);
+      expect(response.status).toBe(401);
+    },
+  );
+
+  it.each(publicRoutes.map(route => [`${route.httpMethod.toUpperCase()} ${route.path}`, route]))(
+    'allows %s without a session',
+    async (_label, route) => {
+      const response = await send(route.httpMethod, route.path);
+      expect(response.status).not.toBe(401);
+    },
+  );
+
+  it('lets CORS preflight through so the real request is not blocked', async () => {
+    const target = protectedRoutes[0];
+    const response = await send('options', target.path);
+
+    expect(response.status).not.toBe(401);
+  });
+
+  it('denies an unknown path under the prefix rather than falling through', async () => {
+    const response = await server.request('get', `${BASE_URL_PREFIX}/definitely-not-a-route`);
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/backend/src/tests/default-auth.runtime.test.ts
+++ b/backend/src/tests/default-auth.runtime.test.ts
@@ -73,6 +73,13 @@ describe('default-deny auth (runtime)', () => {
     },
   );
 
+  it('does not open other verbs on a public path', async () => {
+    const target = publicRoutes[0];
+    const response = await send('post', target.path);
+
+    expect(response.status).toBe(401);
+  });
+
   it('lets CORS preflight through so the real request is not blocked', async () => {
     const target = protectedRoutes[0];
     const response = await send('options', target.path);

--- a/backend/src/tests/default-auth.swagger.test.ts
+++ b/backend/src/tests/default-auth.swagger.test.ts
@@ -1,0 +1,76 @@
+// Swagger must stay reachable without a session - it was public before the default-deny
+// guard, and locking it would be a regression.
+//
+// The interesting case is not the /api-docs HTML but the assets beneath it: Swagger UI is
+// served by `swaggerUi.serve`, which includes express.static(...), so the page pulls
+// swagger-ui.css and swagger-ui-bundle.js from the same mount. An exact-match allow-list
+// would return the HTML shell and 401 every asset, leaving a blank page rather than an
+// honest error - which is exactly the failure this test is here to catch.
+//
+// Nothing is imported statically from '@/config' or '@/app': config reads SWAGGER_ENABLED
+// into a module-level const at import time, and static imports are hoisted above the
+// assignment below. Everything that touches config is therefore imported dynamically.
+
+import session from 'express-session';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { startServer, TestServer } from './helpers/server';
+
+vi.mock('@/services/api.service', () => {
+  const stub = vi.fn(() => Promise.resolve({ data: {} }));
+  return {
+    default: class {
+      get = stub;
+      post = stub;
+      patch = stub;
+      put = stub;
+      delete = stub;
+    },
+  };
+});
+
+vi.mock('@/utils/redis', () => ({
+  isRedisReady: () => true,
+  closeRedisClient: () => Promise.resolve(),
+  destroyRedisClient: () => undefined,
+}));
+
+describe('default-deny auth (swagger)', () => {
+  let server: TestServer;
+  const prefix = process.env.BASE_URL_PREFIX ?? '';
+
+  beforeAll(async () => {
+    process.env.SWAGGER_ENABLED = 'true';
+
+    const { default: App } = (await import('@/app')) as typeof import('@/app');
+    const { CONTROLLERS } = (await import('@/controllers')) as typeof import('@/controllers');
+
+    server = await startServer(new App(CONTROLLERS, new session.MemoryStore()).getServer());
+  });
+
+  afterAll(() => server.close());
+
+  it('mounts swagger at all (guards the rest of this suite from passing vacuously)', async () => {
+    const response = await server.request('get', `${prefix}/api-docs/`);
+
+    expect(response.status).toBe(200);
+  });
+
+  it.each([
+    ['the UI entry point', '/api-docs/'],
+    ['the generated init script', '/api-docs/swagger-ui-init.js'],
+    ['a static stylesheet', '/api-docs/swagger-ui.css'],
+    ['a static bundle', '/api-docs/swagger-ui-bundle.js'],
+    ['the raw spec', '/swagger.json'],
+  ])('serves %s without a session', async (_label, path) => {
+    const response = await server.request('get', `${prefix}${path}`);
+
+    expect(response.status).not.toBe(401);
+  });
+
+  it('does not open sibling paths that merely share a prefix', async () => {
+    const response = await server.request('get', `${prefix}/api-docsomething`);
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/backend/src/tests/fixtures/guard.fixture.controller.ts
+++ b/backend/src/tests/fixtures/guard.fixture.controller.ts
@@ -1,0 +1,57 @@
+// Test-only controller used by default-auth.runtime.test.ts to prove the app-level guard
+// denies on its own.
+//
+// Deliberately NOT listed in src/controllers.ts: `unguarded` carries no auth decorator, so
+// including it would (correctly) fail default-auth.metadata.test.ts. The runtime test
+// mounts it into its own App instance instead. collectRegisteredRoutes() filters on
+// CONTROLLERS, so neither route shows up in the enumerated route lists.
+
+import { Controller, Get, UseBefore } from 'routing-controllers';
+
+import authMiddleware from '@/middlewares/auth.middleware';
+import { Public } from '@/middlewares/public.decorator';
+
+@Controller('/__guard-fixture__')
+export class GuardFixtureController {
+  /**
+   * No @UseBefore(authMiddleware) and no @Public(). Nothing but createDefaultAuthGuard can
+   * stop this handler from answering 200 - which is what makes the 401 assertion a proof
+   * about the guard rather than about a decorator.
+   */
+  @Get('/unguarded')
+  unguarded() {
+    return 'reached';
+  }
+
+  /**
+   * Control case. An unmounted path and an unguarded path both answer 401, so without this
+   * the assertion above would pass just as happily against a controller that was never
+   * registered. A 200 here shows the fixture really is mounted.
+   */
+  @Get('/reachable')
+  @Public('Test fixture - proves the fixture controller is actually mounted')
+  reachable() {
+    return 'reached';
+  }
+}
+
+/**
+ * Covers @Public() applied to a whole controller, with one handler
+ * inside it opting back into auth with @UseBefore(authMiddleware).
+ */
+@Controller('/__public-class-fixture__')
+@Public('Test fixture - whole controller marked public')
+export class PublicControllerFixture {
+  /** Inherits the controller's @Public(), so it answers without a session. */
+  @Get('/inherited')
+  inherited() {
+    return 'reached';
+  }
+
+  /** Asks for auth explicitly. Must stay protected despite the controller being public. */
+  @Get('/protected')
+  @UseBefore(authMiddleware)
+  protectedRoute() {
+    return 'reached';
+  }
+}

--- a/backend/src/tests/helpers/routes.ts
+++ b/backend/src/tests/helpers/routes.ts
@@ -1,0 +1,50 @@
+import { getMetadataArgsStorage } from 'routing-controllers';
+
+import { CONTROLLERS } from '@/controllers';
+import authMiddleware from '@/middlewares/auth.middleware';
+import { resolvePublic } from '@/middlewares/public.decorator';
+
+export interface RegisteredRoute {
+  controllerName: string;
+  handlerName: string;
+  /** Lowercase express verb, e.g. 'get' | 'post'. */
+  httpMethod: string;
+  /** Route path as declared, may contain ':param' segments. */
+  path: string;
+  hasAuthMiddleware: boolean;
+  /** True when the handler carries @Public(). */
+  isPublic: boolean;
+  publicReason?: string;
+}
+
+const buildPath = (controllerRoute: unknown, actionRoute: string | RegExp | undefined): string => {
+  const prefix = typeof controllerRoute === 'string' ? controllerRoute : '';
+  const route = typeof actionRoute === 'string' ? actionRoute : (actionRoute?.source ?? '');
+  return `${prefix}${route}` || '/';
+};
+
+export const collectRegisteredRoutes = (): RegisteredRoute[] => {
+  const storage = getMetadataArgsStorage();
+  const mounted = new Set<unknown>(CONTROLLERS);
+  const controllerRouteByTarget = new Map<unknown, unknown>(storage.controllers.map(controller => [controller.target, controller.route]));
+
+  return storage.actions
+    .filter(action => mounted.has(action.target))
+    .map(action => {
+      const { isPublic, reason } = resolvePublic(action.target, action.method);
+      return {
+        controllerName: (action.target as { name?: string }).name ?? 'unknown',
+        handlerName: action.method,
+        httpMethod: action.type.toLowerCase(),
+        path: buildPath(controllerRouteByTarget.get(action.target), action.route),
+        // Method-level @UseBefore on this action, or a class-level one covering all actions.
+        hasAuthMiddleware: storage.uses.some(
+          use => use.target === action.target && (use.method === undefined || use.method === action.method) && use.middleware === authMiddleware,
+        ),
+        isPublic,
+        publicReason: reason,
+      };
+    });
+};
+
+export const toConcretePath = (path: string): string => path.replace(/:[^/]+/g, '1');

--- a/backend/src/tests/helpers/server.ts
+++ b/backend/src/tests/helpers/server.ts
@@ -1,0 +1,33 @@
+// Boots an express app on an ephemeral port so a test can make real HTTP requests through
+// the production middleware chain.
+
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import type { Application } from 'express';
+
+export interface TestServer {
+  baseUrl: string;
+  request: (method: string, path: string) => ReturnType<typeof fetch>;
+  close: () => Promise<void>;
+}
+
+export const startServer = async (app: Application): Promise<TestServer> => {
+  const server = http.createServer(app);
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+  const { port } = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  return {
+    baseUrl,
+    request: (method, path) => fetch(`${baseUrl}${path}`, { method: method.toUpperCase(), redirect: 'manual' }),
+    close: () =>
+      new Promise<void>(resolve => {
+        server.closeAllConnections();
+        server.close(() => {
+          resolve();
+        });
+      }),
+  };
+};

--- a/backend/vitest.setup.ts
+++ b/backend/vitest.setup.ts
@@ -1,3 +1,19 @@
-// routing-controllers / class-validator decorators read metadata via reflect-metadata.
-// Import it once for the whole test run so decorated classes can be imported in tests.
 import 'reflect-metadata';
+
+// app.ts builds the SAML strategy and reads config at IMPORT time, so the default-deny
+// runtime tests cannot import the app without these. The values are dummies - no SAML
+// flow is exercised, only the auth guard in front of the routes.
+process.env.BASE_URL_PREFIX ??= '/api';
+process.env.SECRET_KEY ??= 'test-secret-key';
+process.env.SAML_ENTRY_SSO ??= 'https://idp.test.local/sso';
+process.env.SAML_CALLBACK_URL ??= 'https://app.test.local/api/saml/login/callback';
+process.env.SAML_LOGOUT_CALLBACK_URL ??= 'https://app.test.local/api/saml/logout/callback';
+process.env.SAML_SUCCESS_REDIRECT ??= 'https://app.test.local';
+process.env.SAML_FAILURE_REDIRECT ??= 'https://app.test.local/login';
+process.env.SAML_ISSUER ??= 'test-issuer';
+// node-saml asserts these are present when the Strategy is constructed. They are never
+// used to sign or verify anything in tests, so placeholder values are enough.
+process.env.SAML_IDP_PUBLIC_CERT ??= 'test-idp-cert';
+process.env.SAML_PRIVATE_KEY ??= 'test-private-key';
+process.env.SAML_PUBLIC_KEY ??= 'test-public-key';
+process.env.ORIGIN ??= 'http://localhost:3000';


### PR DESCRIPTION
Infrastruktur och test för att säkerställa att alla controllers och routes är antingen explicit skyddade bakom auth eller markerade som publika med en dokumenterad anledning.

Bygger på motsvarande PR i Draken: https://github.com/Sundsvallskommun/web-app-draken-public/pull/1126 men med två skillnader:

1. Beroendet av supertest är borta genom en helpermetod.
2. För publika routes måste man ange en anledning till att de är publika.

Liknande lösning finns i MS Bolag, men där injiceras middleware automatiskt genom modifikation av routing-controllers interna state.

TEST

Lägg till en ny route, markera den som publik med `@Public('reason')` och kör backendtesterna. De ska nu faila pga att den publika routen inte lagts till i testet.

Lägg till en ny route, ge den ingen decorator (dvs varken `@Public()` eller `@UseBefore(authMiddleware)`, kör testerna. Dessa failar nu pga att routen saknar decorator.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
